### PR TITLE
Rename other references to predicting-zygosity to cruijff-kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # cruijff-kit
-A reboot of Alessandra's repo now attached to our new Project, "Everything Predictor"!
+A torchtune-based toolkit for fine-tuning and evaluating large language models using twin data and beyond, featuring automated SLURM script generation and preprocessing pipelines.
 
 # Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# predicting-zygosity
+# cruijff-kit
 A reboot of Alessandra's repo now attached to our new Project, "Everything Predictor"!
 
 # Prerequisites

--- a/tests/bit_sequences/readme.md
+++ b/tests/bit_sequences/readme.md
@@ -53,7 +53,7 @@ Generate train.json and test.json into your current working directory and then u
 python generate_slurm_script.py \
   --my_wandb_project predictable_or_not \
   --my_wandb_run_name binary_sequence_test \
-  --input_dir_base /home/niznik/scratch/GitHub/predicting-zygosity/tests/bit_sequences/ \
+  --input_dir_base /home/niznik/scratch/GitHub/cruijff-kit/tests/bit_sequences/ \
   --input_formatting '' \
   --dataset_filename train.json \
   --dataset_val_filename test.json \

--- a/tests/input_training/README.md
+++ b/tests/input_training/README.md
@@ -25,7 +25,7 @@ Use `generate_slurm_script.py` with the following arguments:
 python generate_slurm_script.py \
   --my_wandb_project input_training_tests \
   --my_wandb_run_name false-test \
-  --input_dir_base /home/niznik/scratch/GitHub/predicting-zygosity/tests/input_training/ \
+  --input_dir_base /home/niznik/scratch/GitHub/cruijff-kit/tests/input_training/ \
   --input_formatting '' \
   --dataset_filename simpleCapitalization.json \
   --dataset_val_filename simpleCapitalization.json \
@@ -49,7 +49,7 @@ sbatch finetune_filled.slurm
 python generate_slurm_script.py \
   --my_wandb_project input_training_tests \
   --my_wandb_run_name true-test \
-  --input_dir_base /home/niznik/scratch/GitHub/predicting-zygosity/tests/input_training/ \
+  --input_dir_base /home/niznik/scratch/GitHub/cruijff-kit/tests/input_training/ \
   --input_formatting '' \
   --dataset_filename simpleCapitalization.json \
   --dataset_val_filename simpleCapitalization.json \

--- a/tests/predictable_or_not/README.md
+++ b/tests/predictable_or_not/README.md
@@ -33,7 +33,7 @@ Use `generate_slurm_script.py` with the following arguments:
 python generate_slurm_script.py \
   --my_wandb_project predictable_or_not \
   --my_wandb_run_name pp-false-test \
-  --input_dir_base /home/niznik/scratch/GitHub/predicting-zygosity/tests/predictable_or_not/ \
+  --input_dir_base /home/niznik/scratch/GitHub/cruijff-kit/tests/predictable_or_not/ \
   --input_formatting '' \
   --dataset_filename pp.json \
   --dataset_val_filename pp.json \
@@ -59,7 +59,7 @@ sbatch finetune_filled.slurm
 python generate_slurm_script.py \
   --my_wandb_project predictable_or_not \
   --my_wandb_run_name pp-true-test \
-  --input_dir_base /home/niznik/scratch/GitHub/predicting-zygosity/tests/predictable_or_not/ \
+  --input_dir_base /home/niznik/scratch/GitHub/cruijff-kit/tests/predictable_or_not/ \
   --input_formatting '' \
   --dataset_filename pp.json \
   --dataset_val_filename pp.json \


### PR DESCRIPTION
Closes #64

# Description

Update paths listed in our READMEs to reference the new repo name; also added a slightly better tagline that we can keep iterating on

## New Dependencies

(None)

# Testing Instructions

(None)
