### PR TITLE
Copy slurm out files if run is successful

### DIFF
--- a/templates/finetune_template.slurm
+++ b/templates/finetune_template.slurm
@@ -21,3 +21,4 @@ conda activate <CONDA_ENV>
 mkdir -p <OUTPUT_DIR>logs/wandb
 tune run lora_finetune_single_device \
     --config finetune_filled.yaml
+[ $? == 0 ] && mv slurm-${SLURM_JOB_ID}.out <OUTPUT_DIR>/


### PR DESCRIPTION
Closes #78 

# Description

Added a simple final line to the template slurm script so that the .out file copies into the output folder if the run is successful (I had been manually doing this previously)

## New Dependencies

(None)

# Testing Instructions

On della...
Ran once and the run failed; slurm out file was not transferred
Run once and the run succeeded; slurm out file was transferred
